### PR TITLE
FIX: Correct the "off by one" MSFSSimConnect connection type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.17.5
+This bug fix release provides an important correction for a regression that would prevent recording (and possibly replay as well), due to wrongly creating an IPv4 network connection instead of a local ("pipe") connection.
+
+### Bug Fixes
+- Ensure that the connection is *local* again ("pipe")
+  * Fix the persisted connection type value 
+  * Migrate existing application settings (fix the "off by one" value)
+  * This is a regression introduced with Sky Dolly v0.17.1
+
 ## 0.17.4
 This is a pure maintenance release without any Sky Dolly specific fixes: it provides the most recent Qt framework release with several Windows 11 user interface style related fixes.
 

--- a/src/Kernel/CMakeLists.txt
+++ b/src/Kernel/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(${LIBRARY_NAME}
         src/SettingsConverterV0dot13.h
         src/SettingsConverterV0dot16.h
         src/SettingsConverterV0dot17.h
+        src/SettingsConverterV0dot17dot5.h
         src/SettingsConverter.h src/SettingsConverter.cpp
         src/VersionConfig.h.in
         src/GitInfo.h src/GitInfo.cpp.in

--- a/src/Kernel/include/Kernel/Const.h
+++ b/src/Kernel/include/Kernel/Const.h
@@ -75,6 +75,10 @@ namespace Const {
 
     // Known plugin UUIDs
 
+    // Connect
+    const inline QString MsfsSimConnectPluginUuid {"8ef8d50a-42a1-480a-bee6-b741000e86b4"};
+    const inline QString PathCreatorPluginUuid {"90064498-8afc-45c4-9c0f-30f2d113232d"};
+
     // Import
     const inline QString CsvImportPluginUuid {QStringLiteral("077448de-4909-4c5e-8957-2347afee6708")};
     const inline QString GpxImportPluginUuid {QStringLiteral("13f44df3-1df6-4458-ad29-71f7b185bf3e")};

--- a/src/Kernel/src/SettingsConverter.cpp
+++ b/src/Kernel/src/SettingsConverter.cpp
@@ -27,7 +27,7 @@
 #include <QUuid>
 
 #include "Version.h"
-#include "SettingsConverterV0dot17.h"
+#include "SettingsConverterV0dot17dot5.h"
 #include "SettingsConverter.h"
 
 // PUBLIC
@@ -36,6 +36,6 @@ void SettingsConverter::convertToCurrent(const Version &settingsVersion, QSettin
 {
     const Version currentVersion;
     if (settingsVersion < currentVersion) {
-        SettingsConverterV0dot17::convert(settingsVersion, settings);
+        SettingsConverterV0dot17dot5::convert(settingsVersion, settings);
     }
 }

--- a/src/Kernel/src/SettingsConverterV0dot17dot5.h
+++ b/src/Kernel/src/SettingsConverterV0dot17dot5.h
@@ -1,0 +1,75 @@
+/**
+ * Sky Dolly - The Black Sheep for Your Flight Recordings
+ *
+ * Copyright (c) Oliver Knoll
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+ * to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#ifndef SETTINGSCONVERTERV0DOT17DOT5_H
+#define SETTINGSCONVERTERV0DOT17DOT5_H
+
+#include <QString>
+#include <QStringLiteral>
+#include <QStringBuilder>
+#include <QSettings>
+#include <QByteArray>
+#include <QUuid>
+
+#include <Const.h>
+#include <Version.h>
+
+#include "SettingsConverterV0dot17.h"
+
+class SettingsConverterV0dot17dot5
+{
+public:
+    static inline void convert(const Version &settingsVersion, QSettings &settings) noexcept
+    {
+        if (settingsVersion < Version(QStringLiteral("0.17.0"))) {
+            SettingsConverterV0dot17::convert(settingsVersion, settings);
+        }
+        // The regression ("off by one" connection type) has been introduced with v0.17.1
+        if (settingsVersion >= Version(QStringLiteral("0.17.1"))) {
+            convertMsfsSimConnectPlugin(settings);
+        }
+    }
+
+private:
+    static inline void convertMsfsSimConnectPlugin(QSettings &settings) noexcept
+    {
+        static const QString ConnectionTypeKey {"ConnectionType"};
+        int connectionType {0};
+
+        // MSFS SimConnect
+        settings.beginGroup(QStringLiteral("Plugins/") % QUuid(Const::MsfsSimConnectPluginUuid).toByteArray());
+        {
+            bool ok {true};
+            connectionType = settings.value(ConnectionTypeKey).toInt(&ok);
+            if (ok) {
+                // Fix existing "off by one" value
+                const int newConnectionType = connectionType > 0 ? connectionType - 1 : 0;
+                settings.setValue(ConnectionTypeKey, newConnectionType);
+            }
+        }
+        settings.endGroup();
+    }
+};
+
+#endif // SETTINGSCONVERTERV0DOT17DOT5_H

--- a/src/Plugins/Connect/MSFSSimConnectPlugin/src/MSFSSimConnectSettings.h
+++ b/src/Plugins/Connect/MSFSSimConnectPlugin/src/MSFSSimConnectSettings.h
@@ -53,7 +53,7 @@ public:
     enum struct ConnectionType
     {
         First = 0,
-        Pipe,
+        Pipe = First,
         IPv4,
         IPv6,
         Last = IPv6


### PR DESCRIPTION
- "enum struct ConnectionType" values were "off by one"
- Correct existing plugin settings
- Regression introduced with v0.17.1